### PR TITLE
release workflowでのtest chartではイメージを事前ロードさせない

### DIFF
--- a/.github/actions/test-chart/action.yaml
+++ b/.github/actions/test-chart/action.yaml
@@ -7,6 +7,8 @@ inputs:
     required: true
   build-image:
     default: 'true'
+  load-image:
+    default: 'true'
   docker-cache-dir:
     required: false
 runs:
@@ -31,4 +33,5 @@ runs:
       run: make test-chart TEST_CHART="$chart"
       env:
         TEST_CHART_SKIP_DOCKER_BUILD: ${{ inputs.build-image != 'true' }}
+        TEST_CHART_SKIP_LOAD_IMAGE: ${{ inputs.load-image != 'true' }}
         chart: ${{ inputs.chart }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,7 @@ jobs:
           chart: '${{ steps.generate-chart.outputs.chart-package-path }}'
           node-image: '${{ env.KIND_NODE_IMAGE }}'
           build-image: false
+          load-image: false
       - name: Upload chart package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/hack/test-chart.sh
+++ b/hack/test-chart.sh
@@ -28,4 +28,5 @@ if [[ "$TEST_CHART_SKIP_CHART_BUILD" != "true" ]]; then
   __make chart-internal
 fi
 export E2E_SKIP_BUILD="$TEST_CHART_SKIP_DOCKER_BUILD"
+export E2E_SKIP_LOAD="$TEST_CHART_SKIP_LOAD_IMAGE"
 __make test-e2e

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,10 +59,11 @@ var _ = BeforeSuite(func() {
 	}
 	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
 	// built and available before running the tests. Also, remove the following block.
-	By("loading the manager(Operator) image on Kind")
-	ExpectWithOffset(1, utils.LoadImageToKindCluster()).
-		NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
-
+	if !utils.IsEnvTrue("E2E_SKIP_LOAD") {
+		By("loading the manager(Operator) image on Kind")
+		ExpectWithOffset(1, utils.LoadImageToKindCluster()).
+			NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+	}
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,
 	// we check for its presence before execution.


### PR DESCRIPTION
ghcrからpullさせるため